### PR TITLE
Feature/preprocessing transforms

### DIFF
--- a/pennylane_snowflurry/pennylane_converter.py
+++ b/pennylane_snowflurry/pennylane_converter.py
@@ -32,6 +32,7 @@ SNOWFLURRY_OPERATION_MAP = {
     "PauliZ": "sigma_z({0})",
     "Hadamard": "hadamard({0})",
     "CNOT": "control_x({0},{1})",
+    "CY": "controlled(sigma_y({1}),[{0}])",  # 0 is the control qubit, 1 is the target qubit
     "CZ": "control_z({0},{1})",
     "SWAP": "swap({0},{1})",
     "ISWAP": "iswap({0},{1})",
@@ -39,15 +40,15 @@ SNOWFLURRY_OPERATION_MAP = {
     "RY": "rotation_y({1},{0})",
     "RZ": "rotation_z({1},{0})",
     "Identity": "identity_gate({0})",
-    "CSWAP": NotImplementedError,
-    "CRX": "controlled(rotation_x({2},{0}),[{1}])",
+    "CSWAP": "controlled(swap({1},{2}),[{0}])",  # 0 is the control qubit, 1 and 2 are the target qubits
+    "CRX": "controlled(rotation_x({2},{0}),[{1}])",  # 0 is the angle, 1 is the control qubit, 2 is the target qubit
     "CRY": "controlled(rotation_y({2},{0}),[{1}])",
     "CRZ": "controlled(rotation_z({2},{0}),[{1}])",
-    "PhaseShift": "phase_shift({1},{0})",
-    "ControlledPhaseShift": "controlled(phase_shift({2},{0}),[{1}])",
+    "PhaseShift": "phase_shift({1},{0})",  # 0 is the angle, 1 is the wire
+    "ControlledPhaseShift": "controlled(phase_shift({2},{0}),[{1}])",  # 0 is the angle, 1 is the control qubit, 2 is the target qubit
     "QubitStateVector": NotImplementedError,
     "StatePrep": NotImplementedError,
-    "Toffoli": "toffoli({0},{1},{2})",  # order might be wrong on that one
+    "Toffoli": "toffoli({0},{1},{2})",
     "QubitUnitary": NotImplementedError,
     "U1": NotImplementedError,
     "U2": NotImplementedError,

--- a/pennylane_snowflurry/pennylane_converter.py
+++ b/pennylane_snowflurry/pennylane_converter.py
@@ -40,11 +40,11 @@ SNOWFLURRY_OPERATION_MAP = {
     "RZ": "rotation_z({1},{0})",
     "Identity": "identity_gate({0})",
     "CSWAP": NotImplementedError,
-    "CRX": "controlled(rotation_x({1},{0}),[{2}])",
-    "CRY": "controlled(rotation_y({1},{0}),[{2}])",
-    "CRZ": "controlled(rotation_z({1},{0}),[{2}])",
+    "CRX": "controlled(rotation_x({2},{0}),[{1}])",
+    "CRY": "controlled(rotation_y({2},{0}),[{1}])",
+    "CRZ": "controlled(rotation_z({2},{0}),[{1}])",
     "PhaseShift": "phase_shift({1},{0})",
-    "ControlledPhaseShift": "controlled(phase_shift({1},{0}),[{2}])",
+    "ControlledPhaseShift": "controlled(phase_shift({2},{0}),[{1}])",
     "QubitStateVector": NotImplementedError,
     "StatePrep": NotImplementedError,
     "Toffoli": "toffoli({0},{1},{2})",  # order might be wrong on that one
@@ -93,7 +93,7 @@ class PennylaneConverter:
     snowflurry_gate_object_name = "Gate Object"
 
     # Pattern is found in PyCall.jlwrap object of Snowflurry.QuantumCircuit.instructions
-    snowflurry_str_search_pattern = r"Gate Object: (.*)\nConnected_qubits"
+    snowflurry_str_search_pattern = r"Gate Object: (.*)\n"
 
     #################
     # Class methods #
@@ -116,8 +116,8 @@ class PennylaneConverter:
         self.rng = rng
         self.debugger = debugger
         self.interface = interface
-        
-        #Instance attributes related to Snowflurry
+
+        # Instance attributes related to Snowflurry
         if (
             len(host) != 0
             and len(user) != 0
@@ -268,7 +268,8 @@ class PennylaneConverter:
                 # while the attribute for the Readout object is connected_qubit (singular)
 
             except:
-                print(f"Error while parsing {gate_str}")
+                raise ValueError(f"Error while parsing {gate_str}")
+
             ops.append(op_data)
 
         return ops
@@ -432,6 +433,8 @@ class PennylaneConverter:
 
         # if measurement is a qml.expval
         if isinstance(mp, ExpectationMP):
+            # FIXME : this measurement only works with a single wire
+            # Requires some processing to work with larger matrices
             self.remove_readouts()
             Main.result_state = Main.simulate(Main.sf_circuit)
             if mp.obs is not None and mp.obs.has_matrix:


### PR DESCRIPTION
# Description

Added preprocessing-transforms in  [snowflurry_device.py](https://github.com/calculquebec/pennylane-snowflurry/blob/feature/preprocessing-transforms/pennylane_snowflurry/snowflurry_device.py) so that circuits containing subroutines that are not natively recognized by the plugin and provide a `decompose()` function can be decomposed into simpler operations that are supported.

# Related Issues

Resolves #calculquebec/MonarQ-Hub#1

# Missing commits
Other changes have been merged by mistake in previous merge commit:
- https://github.com/calculquebec/pennylane-snowflurry/commit/9718e0247080d64445e179086f31fc372da27534