### PR TITLE
Add 'autoray<0.8.0' to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pennylane-calculquebec"
 dynamic = ["version"]
 requires-python = ">=3.10"
-dependencies = ["numpy", "pennylane >= 0.36.0", "networkx >= 3.3"]
+dependencies = ["numpy", "pennylane >= 0.36.0", "networkx >= 3.3", "autoray<0.8.0"]
 description = "Pennylane plugin enabling seamless job execution on MonarQ, Calcul Québec’s nonprofit-hosted quantum computer"
 readme = "README.md"
 maintainers = [


### PR DESCRIPTION
Fixes 
```
AttributeError: module 'autoray.autoray' has no attribute 'NumpyMimic'
```

```
$ python -c "import pennylane_calculquebec"
AttributeError: module 'autoray.autoray' has no attribute 'NumpyMimic'
```
since it installs the latest `autoray` (`0.8.0`).