### PR TITLE
Retiré le support de python 3.10

### DIFF
--- a/doc/FR/prise_en_main.ipynb
+++ b/doc/FR/prise_en_main.ipynb
@@ -27,9 +27,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "0. Tout d'abord, assurez-vous d'avoir la version Python ```3.10.X``` d'installée."
-   ]
+   "source": "0. Tout d'abord, assurez-vous d'avoir la version Python ```3.11.X``` d'installée."
   },
   {
    "cell_type": "markdown",

--- a/doc/getting_started.ipynb
+++ b/doc/getting_started.ipynb
@@ -32,7 +32,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "0. First and foremost, you have to make sure to have python version ```3.10.x``` installed"
+   "source": "0. First and foremost, you have to make sure to have python version ```3.11.x``` installed"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pennylane-calculquebec"
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = ["numpy", "pennylane >= 0.36.0", "networkx >= 3.3"]
 description = "Pennylane plugin enabling seamless job execution on MonarQ, Calcul Québec’s nonprofit-hosted quantum computer"
 readme = "README.md"
@@ -25,7 +25,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
@@ -64,7 +63,6 @@ legacy_tox_ini = """
     [tox]
     min_version = 4.0
     env_list =
-        py310
         py311
         py312
         py313


### PR DESCRIPTION
## Description

Mise à jour de la version minimale de python compatible avec le plugin à 3.11.

## Problème résolu / Fonctionnalité ajoutée

Pennylane ne supporte plus la version 3.10 de python.

## Comment tester

Tenter d'installer le plugin dans un environnement python 3.10 doit résulter en un échec

## Numéro de l'issue associée

resolve #200 
