### PR TITLE
Replaced `DefaultExecutionConfig` by `ExecutionConfig` in `base_device.py`

### DIFF
--- a/pennylane_calculquebec/base_device.py
+++ b/pennylane_calculquebec/base_device.py
@@ -7,7 +7,7 @@ from pennylane.devices import Device
 from pennylane.transforms import transform
 from pennylane.transforms.core import TransformProgram
 from pennylane.tape import QuantumScript, QuantumTape
-from pennylane.devices import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices import ExecutionConfig
 from pennylane_calculquebec.API.adapter import ApiAdapter
 from pennylane_calculquebec.processing import PreProcessor, PostProcessor
 from pennylane_calculquebec.processing.config import (
@@ -54,7 +54,7 @@ class BaseDevice(Device):
 
     def preprocess(
         self,
-        execution_config: ExecutionConfig = DefaultExecutionConfig,
+        execution_config = ExecutionConfig,
     ) -> Tuple[TransformProgram, ExecutionConfig]:
         """This function defines the device transfrom program to be applied and an updated execution config.
 
@@ -77,7 +77,7 @@ class BaseDevice(Device):
     def execute(
         self,
         circuits: QuantumTape | list[QuantumTape],
-        execution_config: ExecutionConfig = DefaultExecutionConfig,
+        execution_config = ExecutionConfig,
     ):
         """
         This function runs provided quantum circuit on MonarQ

--- a/pennylane_calculquebec/base_device.py
+++ b/pennylane_calculquebec/base_device.py
@@ -54,7 +54,7 @@ class BaseDevice(Device):
 
     def preprocess(
         self,
-        execution_config = ExecutionConfig,
+        execution_config=ExecutionConfig,
     ) -> Tuple[TransformProgram, ExecutionConfig]:
         """This function defines the device transfrom program to be applied and an updated execution config.
 
@@ -77,7 +77,7 @@ class BaseDevice(Device):
     def execute(
         self,
         circuits: QuantumTape | list[QuantumTape],
-        execution_config = ExecutionConfig,
+        execution_config=ExecutionConfig,
     ):
         """
         This function runs provided quantum circuit on MonarQ


### PR DESCRIPTION
## Description

Remplace la classe dépréciée `DefaultExecutionConfig` par `ExecutionConfig`.

Seul le fichier `base_device.py` et affecté.

Aucun test n'est modifié.

## Problème résolu / Fonctionnalité ajoutée

Désapprobation de la classe `DefaultExecutionConfig` :
https://docs.pennylane.ai/en/stable/development/deprecations.html#pending-deprecations

La classe `ExecutionConfig` est maintenant elle-même la classe par défault pour les configurations d'exécution.

## Numéro de l'issue associée

resolve #221 

